### PR TITLE
chore: refactor formatter and value functions

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,124 +1,20 @@
 package errors
 
-import (
-	"errors"
-	"reflect"
-)
-
 var _ error = Error{}
 
+// Error is an error that wraps another error and adds a key-value pair.
 type Error struct {
 	err    error
 	keyval KeyValuer
 }
 
+// Error returns the error message formatted by the formatter associated with the error.
+// If no formatter is set, it uses the default formatter.
 func (e Error) Error() string {
 	return GetFormatter(e)(e)
 }
 
+// Unwrap returns the underlying error wrapped by this Error.
 func (e Error) Unwrap() error {
 	return e.err
-}
-
-func Value(err error, key any) any {
-	for ; err != nil; err = errors.Unwrap(err) {
-		if e, ok := err.(Error); ok {
-			if e.keyval.Key() == key {
-				return e.keyval.Value()
-			}
-		}
-	}
-
-	return nil
-}
-
-func ValueKV[T KeyValuer](err error) T {
-	var val T
-
-	return ValueT[T](err, val.Key())
-}
-
-func ValueT[T any](err error, key any) T {
-	valT, _ := Value(err, key).(T)
-	return valT
-}
-
-func Values(err error, key any) []any {
-	var values []any
-
-	var e Error
-	for ; err != nil; err = errors.Unwrap(err) {
-		if errors.As(err, &e) {
-			if e.keyval.Key() == key {
-				values = append(values, e.keyval.Value())
-			}
-		}
-	}
-
-	return values
-}
-
-func ValuesT[T any](err error, key any) []T {
-	values := Values(err, key)
-	if len(values) == 0 {
-		return nil
-	}
-
-	tValues := make([]T, 0, len(values))
-	for _, v := range values {
-		if v == nil {
-			continue
-		}
-
-		if t, ok := v.(T); ok {
-			tValues = append(tValues, t)
-		}
-
-	}
-	return tValues
-}
-
-func ValuesKV[T KeyValuer](err error) []T {
-	var val T
-
-	return ValuesT[T](err, val.Key())
-}
-
-func ValuesMapOf(err error, keyType any) map[any][]any {
-	m := make(map[any][]any)
-	for ; err != nil; err = errors.Unwrap(err) {
-		if e, ok := err.(Error); ok {
-			if reflect.TypeOf(e.keyval.Key()) == reflect.TypeOf(keyType) {
-				m[e.keyval.Key()] = append(m[e.keyval.Key()], e.keyval.Value())
-			}
-		}
-	}
-
-	return m
-}
-
-func ValueMap(err error) map[any]any {
-	m := make(map[any]any)
-	for ; err != nil; err = errors.Unwrap(err) {
-		if e, ok := err.(Error); ok {
-			if _, ok := m[e.keyval.Key()]; !ok {
-				m[e.keyval.Key()] = e.keyval.Value()
-			}
-		}
-	}
-
-	return m
-}
-
-func ValueMapOf(err error, keyType any) map[any]any {
-	m := make(map[any]any)
-	for ; err != nil; err = errors.Unwrap(err) {
-		if e, ok := err.(Error); ok {
-			if reflect.TypeOf(e.keyval.Key()) == reflect.TypeOf(keyType) {
-				m[e.keyval.Key()] = e.keyval.Value()
-			}
-		}
-	}
-
-	return m
 }

--- a/error_test.go
+++ b/error_test.go
@@ -1,1 +1,0 @@
-package errors

--- a/formatter.go
+++ b/formatter.go
@@ -2,11 +2,20 @@ package errors
 
 import "strings"
 
+var (
+	_ KeyValuer = Formatter(nil)
+
+	// DefaultFormatter is the default formatter used when no custom formatter is set.
+	// It defaults to `FullFormatter`, which provides a comprehensive view of the error.
+	DefaultFormatter = FullFormater
+)
+
 type formatterKey struct{}
 
+// Formatter is a function type that formats an error into a string representation.
+// It can be used to customize how errors are displayed, including their severity, code, and context.
+// It is typically used in conjunction with the `errors.With` function to attach a custom formatter to an error.
 type Formatter func(err error) string
-
-var _ KeyValuer = Formatter(nil)
 
 func (Formatter) Key() any {
 	return formatterKey{}
@@ -20,53 +29,92 @@ func (Formatter) String() string {
 	return "<ErrorFormatter>"
 }
 
+// GetFormatter retrieves the custom formatter associated with the error.
+// If no custom formatter is set, it returns the default formatter, which is `FullFormatter`.
 func GetFormatter(err error) Formatter {
 	if formatter, ok := Value(err, formatterKey{}).(Formatter); ok {
 		return formatter
 	}
 
-	return defaultFormater
+	return DefaultFormatter
 }
 
-func defaultFormater(err error) string {
+// FullFormater formats the error with its operation stack, severity, code, and key-value pairs.
+// It provides a comprehensive view of the error, including its context and any additional information that has been attached to it.
+// The format is as follows:
+// operation2: ... operation1: [severity] (code) root error message {key1: value1, key2: value2, ...}
+func FullFormater(err error) string {
 	sb := strings.Builder{}
 	sb.Grow(32)
-	ops := GetOpStack(err)
-	if len(ops) > 0 {
-		sb.WriteString(ops)
-		sb.WriteString(": ")
-	}
 
-	severity := GetSeverity(err)
-	if severity != SeverityUnset {
-		sb.WriteString("[")
-		sb.WriteString(severity.String())
-		sb.WriteString("] ")
-	}
-
-	code := GetCode(err)
-	if code != NoCode {
-		sb.WriteString("(")
-		sb.WriteString(code.String())
-		sb.WriteString(") ")
-	}
+	writeOpStack(&sb, GetOpStack(err))
+	writeSeverity(&sb, GetSeverity(err))
+	writeCode(&sb, GetCode(err))
 
 	sb.WriteString(GetRootError(err).Error())
-	context := ValueMapOf(err, "")
-	if len(context) > 0 {
-		sb.WriteString(" {")
-		shouldAddComma := false
-		for k, v := range context {
-			if shouldAddComma {
-				sb.WriteString(", ")
-			}
-			sb.WriteString(k.(string))
-			sb.WriteString(": ")
-			sb.WriteString(v.(string))
-			shouldAddComma = true
-		}
-		sb.WriteString("}")
-	}
+	writeKV(&sb, ValueAllSlice(err))
 
 	return sb.String()
+}
+
+// RootErrorFormatter returns the root error's message.
+func RootErrorFormatter(err error) string {
+	return GetRootError(err).Error()
+}
+
+// RootErrorKVFormater formats the root error's message along with its key-value pairs.
+func RootErrorKVFormater(err error) string {
+	sb := strings.Builder{}
+	sb.Grow(32)
+
+	sb.WriteString(GetRootError(err).Error())
+	writeKV(&sb, ValueAllSlice(err))
+
+	return sb.String()
+}
+
+func writeCode(sb *strings.Builder, code Code) {
+	if code == NoCode {
+		return
+	}
+	sb.WriteString("(")
+	sb.WriteString(code.String())
+	sb.WriteString(") ")
+}
+
+func writeSeverity(sb *strings.Builder, severity Severity) {
+	if severity == SeverityUnset {
+		return
+	}
+	sb.WriteString("[")
+	sb.WriteString(severity.String())
+	sb.WriteString("] ")
+}
+
+func writeOpStack(sb *strings.Builder, ops string) {
+	if ops == "" {
+		return
+	}
+	sb.WriteString(ops)
+	sb.WriteString(": ")
+}
+
+func writeKV(sb *strings.Builder, kvs []KeyValuer) {
+	if len(kvs) <= 0 {
+		return
+	}
+	sb.WriteString(" {")
+	shouldAddComma := false
+	for _, kv := range kvs {
+		if shouldAddComma {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(stringify(kv.Key()))
+		sb.WriteString(": ")
+		sb.WriteString(kv.String())
+
+		shouldAddComma = true
+	}
+
+	sb.WriteString("}")
 }

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -17,11 +17,14 @@ func TestGetFormatter(t *testing.T) {
 		errors.Op("op 2"),
 		errors.SeverityInput,
 		errors.Code("BAD_REQUEST"),
-		errors.KV("key 1", "value 1"),
-		errors.KV("key 2", "value 2"),
+		errors.KV("str", "value"),
+		errors.KV("int", 2),
+		errors.KV("slice", []string{"a", "b", "c"}),
+		errors.KV("map", map[string]int{"key 1": 1, "key 2": 2}),
 	)
-	if err.Error() != "op 2: op 1: [input] (BAD_REQUEST) some error {key 2: value 2, key 1: value 1}" {
-		t.Error("expected some error, got", err.Error())
+	expectedErrorMsg := `op 2: op 1: [input] (BAD_REQUEST) some error {map: map[key 1:1 key 2:2], slice: [a b c], int: 2, str: value}`
+	if err.Error() != expectedErrorMsg {
+		t.Errorf("expected '%s', got '%s'", expectedErrorMsg, err.Error())
 	}
 
 	err = errors.With(err, errors.Formatter(func(err error) string {

--- a/kv.go
+++ b/kv.go
@@ -1,7 +1,12 @@
 package errors
 
-import "reflect"
+import (
+	"fmt"
+	"strconv"
+)
 
+// KeyValuer is an interface for key-value pairs that can be used in errors.
+// It provides methods to retrieve the key, value, and a string representation of the value.
 type KeyValuer interface {
 	Key() any
 	Value() any
@@ -27,6 +32,7 @@ func (kv KeyValue) String() string {
 	return stringify(kv.value)
 }
 
+// KV is a constructor for KeyValuer types.
 func KV(key any, value any) KeyValuer {
 	return KeyValue{
 		key:   key,
@@ -44,10 +50,12 @@ func stringify(v any) string {
 		return s.String()
 	case string:
 		return s
+	case int:
+		return strconv.Itoa(s)
 	case nil:
 		return "<nil>"
 	}
-	return reflect.TypeOf(v).String()
+	return fmt.Sprintf("%v", v)
 }
 
 type stringer interface {

--- a/value.go
+++ b/value.go
@@ -1,0 +1,148 @@
+package errors
+
+import (
+	"errors"
+	"reflect"
+)
+
+// Value returns the last (more recent) value associated with the given key from the error chain.
+func Value(err error, key any) any {
+	for ; err != nil; err = errors.Unwrap(err) {
+		if e, ok := err.(Error); ok {
+			if e.keyval.Key() == key {
+				return e.keyval.Value()
+			}
+		}
+	}
+
+	return nil
+}
+
+// ValueT returns the value associated with the given key from the error chain, cast to type T.
+func ValueT[T any](err error, key any) T {
+	valT, _ := Value(err, key).(T)
+	return valT
+}
+
+// Values returns a slice of values associated with the given key from the error chain.
+// It traverses the error chain and collects all values that match the specified key.
+// If there are multiple values for the same key, all of them are included in the slice.
+func Values(err error, key any) []any {
+	var values []any
+
+	var e Error
+	for ; err != nil; err = errors.Unwrap(err) {
+		if errors.As(err, &e) {
+			if e.keyval.Key() == key {
+				values = append(values, e.keyval.Value())
+			}
+		}
+	}
+
+	return values
+}
+
+// ValuesT returns a slice of values associated with the given key from the error chain, cast to type T.
+// It traverses the error chain and collects all values that match the specified key.
+// If there are multiple values for the same key, all of them are included in the slice.
+func ValuesT[T any](err error, key any) []T {
+	values := Values(err, key)
+	if len(values) == 0 {
+		return nil
+	}
+
+	tValues := make([]T, 0, len(values))
+	for _, v := range values {
+		if v == nil {
+			continue
+		}
+
+		if t, ok := v.(T); ok {
+			tValues = append(tValues, t)
+		}
+
+	}
+	return tValues
+}
+
+// ValueAllSlice returns a slice of all values from the error chain.
+// It skips built-in key-value pairs like code, severity, operation, and formatter.
+// If there are multiple values for the same key, only the first occurrence (last added) is included.
+func ValueAllSlice(err error) []KeyValuer {
+	var values []KeyValuer
+	processed := make(map[any]struct{})
+
+	for ; err != nil; err = errors.Unwrap(err) {
+		if e, ok := err.(Error); ok {
+			if isBuiltInKeyValuer(e.keyval.Key()) {
+				continue
+			}
+			if _, exists := processed[e.keyval.Key()]; !exists {
+				values = append(values, e.keyval)
+				processed[e.keyval.Key()] = struct{}{}
+			}
+		}
+	}
+
+	return values
+}
+
+// ValuesMapOf returns a map of key-value pairs from the error chain, filtered by the specified key type.
+// It collects all values associated with the same key, allowing multiple values for the same key.
+func ValuesMapOf(err error, keyType any) map[any][]any {
+	m := make(map[any][]any)
+	for ; err != nil; err = errors.Unwrap(err) {
+		if e, ok := err.(Error); ok {
+			if reflect.TypeOf(e.keyval.Key()) == reflect.TypeOf(keyType) {
+				m[e.keyval.Key()] = append(m[e.keyval.Key()], e.keyval.Value())
+			}
+		}
+	}
+
+	return m
+}
+
+// ValueMap returns a map of key-value pairs from the error chain.
+// It skips built-in key-value pairs like code, severity, operation, and formatter.
+// If there are multiple values for the same key, only the first occurrence (last added) is included.
+func ValueMap(err error) map[any]any {
+	m := make(map[any]any)
+	for ; err != nil; err = errors.Unwrap(err) {
+		if e, ok := err.(Error); ok {
+			if isBuiltInKeyValuer(e.keyval.Key()) {
+				continue
+			}
+			if _, ok := m[e.keyval.Key()]; !ok {
+				m[e.keyval.Key()] = e.keyval.Value()
+			}
+		}
+	}
+
+	return m
+}
+
+// ValueMapOf returns a map of key-value pairs from the error chain, filtered by the specified key type.
+// If there are multiple values for the same key, only the first occurrence (last added) is included.
+func ValueMapOf(err error, keyType any) map[any]any {
+	m := make(map[any]any)
+	for ; err != nil; err = errors.Unwrap(err) {
+		if e, ok := err.(Error); ok {
+			if reflect.TypeOf(e.keyval.Key()) == reflect.TypeOf(keyType) {
+				if _, ok := m[e.keyval.Key()]; !ok {
+					m[e.keyval.Key()] = e.keyval.Value()
+				}
+			}
+		}
+	}
+
+	return m
+}
+
+func isBuiltInKeyValuer(key any) bool {
+	switch key {
+	case codeKey{}, severityKey{}, opKey{}, formatterKey{}:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
Refactor the Value functions and the formatter to fix an error with the formatter when the key was not a string.

The Value* functions were refactored to be more consistent. Now Value* returnas always the first occurrence and Values* returns all occurrences of a key.

Now the formatter will print all the keys in the reverse order of creation (most recent first).

Other formatters were added for convenience.