### PR TITLE
feat: automatic op

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # errors
 
-A golang package to create useful errors.
+A golang package to create meaningful errors.
 
-## Using the `errors` package
+This package allows to inject any type of values into the errors.
+
+## TL;DR Using the `errors` package
 
 Import the package:
 
@@ -16,6 +18,8 @@ Use `errors.With()`:
 
 ``` go
 func doStuff() error {
+	// Custom Op, this will override the automatic behavior that is to add the
+	// full name of the current function as the Op.
 	const op = errors.Op("doStuff")
 
 	err := fmt.Errorf("some error")
@@ -27,5 +31,148 @@ func doStuff() error {
 		errors.KV("context2", "value2"),
 	)
 }
+```
+
+Fetch values with `errors.Value*` functions:
+
+``` go
+// Examples on how to retrieve values
+val := errors.Value(err, mykey)
+valStr := errors.ValueT[string](err, mykey)
+
+code := errors.GetCode(err)
+severity := errors.GetSeverity(err)
+```
+
+## Core concepts
+
+The `errors.Error` is a combination of a an `error` and a key-value pair, much 
+like a `context.Context`:
+
+``` go
+type Error struct {
+	err    error
+	keyval KeyValuer
+}
+
+```
+
+The key-value pair is any type that implements the `KeyValuer` interface:
+
+``` go
+type KeyValuer interface {
+	Key() any
+	Value() any
+	String() string
+}
+```
+
+The `errors.With()` functions will wrap the given error with a list of 
+key-values. If more than one key-value is given, they will be chained together.
+
+``` mermaid
+flowchart LR
+E3[Key: Op<br>Value: mypkg.MyFunc] --> |err| E2
+E2["Key: Severity<br>Value: INPUT"] --> |err| E1
+E1[Key: Code<br>Value: BAD_INPUT] --> |err| RootError(Root Error)
+```
+
+## Built-in KeyValuers
+
+This package provides some built-in key-values.
+
+### Op (Operation)
+
+The operation (or function) that was running when the error was reported.
+
+This is used to make a call stack of operations being performed when the error 
+occurred.
+
+It is set automatically by `errors.With()` with the name of the function, as 
+reported by the go's `runtime` package. It can be overwritten by passing
+`errors.Op("your op")` to `errors.With()`. 
+
+When adding Op automatically,  it checks the most recent `Op` before adding a
+new one so it does not stack repetitive functions names.
+
+This can be disabled by setting `errors.AutomaticallyAddOp = false`.
+
+### Severity 
+
+This can be used to indicate the severity of an error. It can be:
+
+- Input
+- Runtime
+- Fatal
+
+`Input` indicates that the error was caused by bad input. The operation should
+not be retried and whoever called this function should be notified to not send
+this input again. In HTTP language, this should translate to a status code 400.
+
+`Runtime` indicates that something outside the application failed. A retry would
+probably change the outcome. For example, a timeout when connection to the 
+database.
+
+`Fatal` indicates that the code was not ready do handle this and the developers
+should be notified about an error on their application.
+
+### Code
+
+This is a simple string to be used as error codes so your application can 
+differentiate different errors. 
+
+Whoever receives this error code should write a switch case to handle the 
+different possible codes.
+
+``` go
+switch errors.GetCode(err) {
+	case MyCode1:
+		// handle MyCode1
+	case MyCode2:
+		// handle MyCode2
+	default:
+	    // handle unknown code
+}
+```
+
+### KV
+
+This is an arbitrary key-value pair that can be used to inject extra content in
+the error.
+
+All values are printed by the default error formatter as `{key: value, ...}`.
+
+The key can be any comparable value.
+
+### Formatter
+
+This is a special type that changes the behavior of `Error() string`  function.
+
+This can be used to change how the error is printed. For example, we would want
+the full error message in the logs but only the root error when returning 
+through an API.
+
+``` go
+err = errors.With(err, errors.RootErrorFormatter))
+```
+
+The `errors.FullFormater` is the default and will print something like (from the
+example package):
+
+``` text
+customOpExample: main.doGreetings.func1 (line 58): main.doGreetings: main.greetings: main.greeter[...].sayHello: [fatal] (RUNTIME_ERROR) name cannot be empty {context3: value3, context2: value2, context1: value1}
+```
+
+The `errors.RootErrorFormatter` will only print the root error:
+
+``` text
+name cannot be empty
+```
+
+And there is a variation `errors.RootErrorKVFormatter` that will print the 
+root error with the KV as context.
+
+``` text
+name cannot be empty {context3: value3, context2: value2, context1: value1}
 ```
 

--- a/example/main.go
+++ b/example/main.go
@@ -76,6 +76,9 @@ func main() {
 
 	fmt.Println("Default formatter ==>", err)
 
+	fmt.Println("Root error formatter ==>", errors.With(err, errors.RootErrorFormatter))
+	fmt.Println("Root error formatter with KV ==>", errors.With(err, errors.RootErrorKVFormatter))
+
 	err = errors.With(err, errors.Formatter(func(err error) string {
 		return fmt.Sprintf("formatted error: %s", errors.GetRootError(err))
 	}))

--- a/example/main.go
+++ b/example/main.go
@@ -1,40 +1,85 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 
 	"github.com/arquivei/errors"
 )
 
-func doStuff() error {
-	const op = errors.Op("doStuff")
-	err := fmt.Errorf("some error")
+type name string
 
-	return errors.With(err,
-		errors.SeverityRuntime, op,
-		errors.Code("RUNTIME_ERROR"),
+func (n name) String() string {
+	return string(n)
+}
+
+type greeter[T fmt.Stringer] struct {
+	name T
+}
+
+func (g greeter[T]) sayHello() error {
+	if g.name.String() != "" {
+		fmt.Printf("Hello, %s!\n", g.name)
+		return nil
+	}
+	return errors.With(fmt.Errorf("name cannot be empty"),
+		errors.SeverityInput,
+		errors.Code("BAD_REQUEST"),
 		errors.KV("context1", "value1"),
 		errors.KV("context2", "value2"),
 	)
 }
 
-func doMoreStuff() error {
-	err := doStuff()
-	return errors.With(err,
-		errors.SeverityFatal,
-		errors.Op("doMoreStuff"),
-		errors.KV("context3", "value3"),
-	)
+func greetings(n name) error {
+	err := greeter[name]{name: n}.sayHello()
+	if err != nil {
+		// This is to show that the Op will not be added twice and context1 will be overridden
+		err = errors.With(err, errors.KV("context1", "this will be overridden"))
+
+		return errors.With(err,
+			errors.SeverityRuntime,
+			errors.Code("RUNTIME_ERROR"),
+			errors.KV("context1", "value1"),
+			errors.KV("context2", "value2"),
+		)
+	}
+	fmt.Println("Greetings sent successfully!")
+	return nil
+}
+
+func doGreetings(n name) (err error) {
+	err = greetings(n)
+	if err != nil {
+		err = errors.With(err)
+	}
+	// Wrapping in an anonymous function to simulate a call stack without caller name
+	defer func() {
+		if err != nil {
+			err = errors.With(err,
+				errors.SeverityFatal,
+				errors.KV("context3", "value3"),
+			)
+		}
+	}()
+
+	return
 }
 
 func main() {
+	flag.Parse()
+	n := ""
+	if flag.NArg() > 0 {
+		n = flag.Arg(0)
+	}
+	err := doGreetings(name(n))
+	err = errors.With(err, errors.Op("customOpExample"))
 
-	err := doMoreStuff()
-	fmt.Println(err)
+	fmt.Println("Default formatter ==>", err)
 
 	err = errors.With(err, errors.Formatter(func(err error) string {
 		return fmt.Sprintf("formatted error: %s", errors.GetRootError(err))
 	}))
 
-	fmt.Println(err)
+	fmt.Println("Custom formatter ==>", err)
+
 }

--- a/formatter.go
+++ b/formatter.go
@@ -43,7 +43,7 @@ func GetFormatter(err error) Formatter {
 // It provides a comprehensive view of the error, including its context and any additional information that has been attached to it.
 // The format is as follows:
 // operation2: ... operation1: [severity] (code) root error message {key1: value1, key2: value2, ...}
-func FullFormater(err error) string {
+var FullFormater Formatter = func(err error) string {
 	sb := strings.Builder{}
 	sb.Grow(32)
 
@@ -58,12 +58,12 @@ func FullFormater(err error) string {
 }
 
 // RootErrorFormatter returns the root error's message.
-func RootErrorFormatter(err error) string {
+var RootErrorFormatter Formatter = func(err error) string {
 	return GetRootError(err).Error()
 }
 
-// RootErrorKVFormater formats the root error's message along with its key-value pairs.
-func RootErrorKVFormater(err error) string {
+// RootErrorKVFormatter formats the root error's message along with its key-value pairs.
+var RootErrorKVFormatter Formatter = func(err error) string {
 	sb := strings.Builder{}
 	sb.Grow(32)
 

--- a/with.go
+++ b/with.go
@@ -1,20 +1,89 @@
 package errors
 
 import (
+	"os"
 	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
 )
+
+var (
+	// AutomaticallyAddOp determines whether the Op should be automatically added
+	// to errors when using the With function.
+	// If set to true, the Op will be automatically added to errors that do not already have an Op.
+	AutomaticallyAddOp = true
+	// VerboseOpOnAnonymousFunctions determines whether the Op should include file and line information
+	// for anonymous functions.
+	// If set to true, the Op will include the line number where the anonymous function was defined.
+	VerboseOpOnAnonymousFunctions = true
+)
+
+func init() {
+	AutomaticallyAddOp = mustGetBoolEnv("ERRORS_AUTOMATICALLY_ADD_OP", AutomaticallyAddOp)
+	VerboseOpOnAnonymousFunctions = mustGetBoolEnv("ERRORS_VERBOSE_OP_ON_ANONYMOUS_FUNCTIONS", VerboseOpOnAnonymousFunctions)
+}
+
+func mustGetBoolEnv(envName string, defaultValue bool) bool {
+	envValue := os.Getenv(envName)
+	if envValue == "" {
+		return defaultValue
+	}
+	val, err := strconv.ParseBool(envValue)
+	if err != nil {
+		panic("invalid value for " + envName + ": " + envValue + ", must be true or false")
+	}
+	return val
+}
 
 func With(err error, keyvalues ...KeyValuer) error {
 	if err == nil {
 		return nil
 	}
 
+	shouldAddAutomaticOp := AutomaticallyAddOp
+
 	for _, keyval := range keyvalues {
 		if !reflect.TypeOf(keyval.Key()).Comparable() {
 			panic("key is not comparable")
 		}
 		err = Error{err: err, keyval: keyval}
+		if keyval.Key() == (opKey{}) {
+			shouldAddAutomaticOp = false
+		}
+	}
+
+	if shouldAddAutomaticOp {
+		return withAutomaticOp(err)
 	}
 
 	return err
+}
+
+func withAutomaticOp(err error) error {
+	op := Op(getWithCaller())
+	if ValueT[Op](err, opKey{}) == op {
+		return err // Op already exists, no need to add it again
+	}
+	return With(err, Op(getWithCaller()))
+}
+
+func getWithCaller() string {
+	pc, _, line, ok := runtime.Caller(3)
+	if !ok {
+		return "<unknown function>"
+	}
+
+	funcName := runtime.FuncForPC(pc).Name()
+	if VerboseOpOnAnonymousFunctions && isAnonymousFunction(funcName) {
+		funcName += " (line " + strconv.Itoa(line) + ")"
+	}
+
+	return funcName
+}
+
+// isAnonymousFunction checks if the function name indicates an anonymous function.
+func isAnonymousFunction(funcName string) bool {
+	parts := strings.Split(funcName, ".")
+	return strings.HasPrefix(parts[len(parts)-1], "func")
 }

--- a/with.go
+++ b/with.go
@@ -1,7 +1,6 @@
 package errors
 
 import (
-	"os"
 	"reflect"
 	"runtime"
 	"strconv"
@@ -18,23 +17,6 @@ var (
 	// If set to true, the Op will include the line number where the anonymous function was defined.
 	VerboseOpOnAnonymousFunctions = true
 )
-
-func init() {
-	AutomaticallyAddOp = mustGetBoolEnv("ERRORS_AUTOMATICALLY_ADD_OP", AutomaticallyAddOp)
-	VerboseOpOnAnonymousFunctions = mustGetBoolEnv("ERRORS_VERBOSE_OP_ON_ANONYMOUS_FUNCTIONS", VerboseOpOnAnonymousFunctions)
-}
-
-func mustGetBoolEnv(envName string, defaultValue bool) bool {
-	envValue := os.Getenv(envName)
-	if envValue == "" {
-		return defaultValue
-	}
-	val, err := strconv.ParseBool(envValue)
-	if err != nil {
-		panic("invalid value for " + envName + ": " + envValue + ", must be true or false")
-	}
-	return val
-}
 
 func With(err error, keyvalues ...KeyValuer) error {
 	if err == nil {

--- a/with_test.go
+++ b/with_test.go
@@ -8,10 +8,14 @@ import (
 
 func TestWithNoKeyValues(t *testing.T) {
 	rootErr := errors.New("some error")
-	err := errors.With(rootErr)
 
-	if err != rootErr {
-		t.Error("expected", rootErr, "got", err)
+	err := errors.With(rootErr)
+	if err == nil {
+		t.Fatal("expected non-nil error, got nil")
+	}
+	var e errors.Error
+	if !errors.As(err, &e) {
+		t.Fatalf("expected error to be of type errors.Error, got %T", err)
 	}
 }
 


### PR DESCRIPTION
Adds Op automatically when using `errors.With`. The default value comes
from go's runtime and will be something like package.funcname.

If an Op was manually added the automatic Op will be skipped.

For anonymous functions a line number is also added.

Both the line number and automatic op can be turned off by Global
variables and environment variables.

Example of a complete error: `main.doGreetings.func1 (line 52): main.doGreetings: main.greetings: sayHello: [fatal] (RUNTIME_ERROR) name cannot be empty {context3: value3, context2: value2, context1: value1}`