### PR TITLE
chore: better code doc. and CodeUnset rename

### DIFF
--- a/code.go
+++ b/code.go
@@ -4,7 +4,8 @@ type Code string
 
 var _ KeyValuer = Code("")
 
-const NoCode Code = ""
+// CodeUnset is the default value for Code, indicating no specific code is set.
+const CodeUnset Code = ""
 
 func (c Code) Key() any {
 	return codeKey{}
@@ -20,11 +21,12 @@ func (c Code) String() string {
 
 type codeKey struct{}
 
+// GetCode retrieves the Code from an error, returning CodeUnset if no code is set.
 func GetCode(err error) Code {
 	val := Value(err, codeKey{})
 	if code, ok := val.(Code); ok {
 		return code
 	}
 
-	return NoCode
+	return CodeUnset
 }

--- a/code_test.go
+++ b/code_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestGetCode(t *testing.T) {
 	err := errors.New("some error")
-	if errors.GetCode(err) != errors.NoCode {
+	if errors.GetCode(err) != errors.CodeUnset {
 		t.Error("expected NoCode, got", errors.GetCode(err))
 	}
 

--- a/formatter.go
+++ b/formatter.go
@@ -74,7 +74,7 @@ var RootErrorKVFormatter Formatter = func(err error) string {
 }
 
 func writeCode(sb *strings.Builder, code Code) {
-	if code == NoCode {
+	if code == CodeUnset {
 		return
 	}
 	sb.WriteString("(")

--- a/op.go
+++ b/op.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 )
 
+// Op represents an operation in the error stack.
 type Op string
 
 var _ KeyValuer = Op("")
@@ -22,6 +23,10 @@ func (op Op) String() string {
 
 type opKey struct{}
 
+// GetOpStack retrieves the operation stack from an error.
+// It returns a string representation of the operations in the stack,
+// formatted as "op1: op2: ...", where each operation is separated by ": ".
+// If no operations are found, it returns an empty string.
 func GetOpStack(err error) string {
 	ops := Values(err, opKey{})
 	if len(ops) == 0 {

--- a/with.go
+++ b/with.go
@@ -18,6 +18,7 @@ var (
 	VerboseOpOnAnonymousFunctions = true
 )
 
+// With adds key-value pairs to an error, allowing for additional context.
 func With(err error, keyvalues ...KeyValuer) error {
 	if err == nil {
 		return nil


### PR DESCRIPTION
Rename `NoCode` to `CodeUnset` to better reflect its purpose as the default unset value for Code type.

Add comprehensive documentation to exported types and functions in the package, improving code clarity and maintainability.