### PR TITLE
feat: don't panic

### DIFF
--- a/dont_panic.go
+++ b/dont_panic.go
@@ -1,0 +1,69 @@
+package errors
+
+import (
+	"runtime"
+	"strings"
+)
+
+// CodePanic is set when a panic occurs in the DontPanic function.
+var CodePanic Code = "PANIC"
+
+// DontPanic executes the provided function and recovers from any panic that occurs.
+// It returns an error containing the panic information if a panic occurs,
+// else it returns nil or the error returned by func() error.
+// If a panic occurs, it sets:
+// - Code to CodePanic
+// - Op to the operation where the panic occurred
+// - Severity to SeverityFatal
+func DontPanic[F func() | func() error](fn F) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = With(Errorf("panic: %v", r), getPanicOp(), CodePanic, SeverityFatal)
+		}
+	}()
+	switch f := any(fn).(type) {
+	case func():
+		f()
+	case func() error:
+		err = f()
+	}
+	return
+}
+
+func getPanicOp() (op Op) {
+	// find the panic operation in the stack trace
+	callers := make([]uintptr, 10)
+	runtime.Callers(1, callers)
+	pcIdx := findPcAfterPanic(callers)
+
+	// If we can't find the panic operation, return an unknown operation
+	if pcIdx == -1 {
+		return opUnknownFunction
+	}
+
+	return getCallerOp(callers[pcIdx], true)
+}
+
+func findPcAfterPanic(callers []uintptr) int {
+	found := -1
+
+	// Look for the runtime.gopanic function in the stack trace
+	for i, pc := range callers {
+		if runtime.FuncForPC(pc).Name() == "runtime.gopanic" {
+			found = i + 1
+		}
+	}
+	if found == -1 {
+		return -1 // No panic found
+	}
+
+	// Skip runtime functions in the stack trace to find the actual panic location
+	for i := found; i < len(callers); i++ {
+		if !strings.HasPrefix(runtime.FuncForPC(callers[i]).Name(), "runtime.") {
+			break
+		}
+		found = i + 1
+	}
+
+	return found
+}

--- a/dont_panic_test.go
+++ b/dont_panic_test.go
@@ -1,0 +1,70 @@
+package errors
+
+import (
+	"testing"
+)
+
+func TestDontPanic(t *testing.T) {
+	// This test is designed to ensure that the package does not panic
+	// when using the standard error functions.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("unexpected panic: %v", r)
+		}
+	}()
+
+	fnNoPanic := func() error {
+		return nil
+	}
+
+	fnNoPanic2 := func() {}
+
+	err := DontPanic(fnNoPanic)
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	err = DontPanic(fnNoPanic2)
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+
+	fn := func() error {
+		panic(New("my panic"))
+	}
+
+	err = DontPanic(fn)
+	if err == nil {
+		t.Fatal("expected non-nil error, got nil")
+	}
+
+	fn2 := func() {
+		panic("another panic")
+	}
+
+	err = DontPanic(fn2)
+	if err == nil {
+		t.Fatal("expected non-nil error, got nil")
+	}
+
+}
+
+func Test_getPanicOp(t *testing.T) {
+	op := getPanicOp()
+	if op != opUnknownFunction {
+		t.Errorf("expected unkown function, got %v", op)
+	}
+
+	err := DontPanic(func() {
+		s := []string{}
+		s[1] = "this should panic"
+	})
+
+	if err == nil {
+		t.Fatal("expected non-nil error, got nil")
+	}
+
+	expectedOp := Op("errors.Test_getPanicOp.func1 (dont_panic_test.go:59)")
+	if op := ValueT[Op](err, opKey{}); op != expectedOp {
+		t.Errorf("expected operation '%s', got ;'%s'", expectedOp, op)
+	}
+}

--- a/example/main.go
+++ b/example/main.go
@@ -65,6 +65,10 @@ func doGreetings(n name) (err error) {
 	return
 }
 
+func thisWillPanic() {
+	panic("this will panic")
+}
+
 func main() {
 	flag.Parse()
 	n := ""
@@ -85,4 +89,12 @@ func main() {
 
 	fmt.Println("Custom formatter ==>", err)
 
+	err = errors.DontPanic(func() {
+		panic("hello anonymous function panic")
+	})
+
+	fmt.Println("DontPanic (anonymous) ==>", err)
+
+	err = errors.DontPanic(thisWillPanic)
+	fmt.Println("DontPanic (named) ==>", err)
 }

--- a/formatter.go
+++ b/formatter.go
@@ -110,7 +110,7 @@ func writeKV(sb *strings.Builder, kvs []KeyValuer) {
 			sb.WriteString(", ")
 		}
 		sb.WriteString(stringify(kv.Key()))
-		sb.WriteString(": ")
+		sb.WriteString("=")
 		sb.WriteString(stringify(kv.Value()))
 
 		shouldAddComma = true

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -41,7 +41,7 @@ func TestGetFormatter(t *testing.T) {
 		errors.KV("slice", []string{"a", "b", "c"}),
 		errors.KV("map", map[string]int{"key 1": 1, "key 2": 2}),
 	)
-	expectedErrorMsg := `op 2: op 1: [input] (BAD_REQUEST) some error {map: map[key 1:1 key 2:2], slice: [a b c], int: 2, str: value}`
+	expectedErrorMsg := `op 2: op 1: [input] (BAD_REQUEST) some error {map=map[key 1:1 key 2:2], slice=[a b c], int=2, str=value}`
 	if err.Error() != expectedErrorMsg {
 		t.Errorf("expected '%s', got '%s'", expectedErrorMsg, err.Error())
 	}
@@ -79,7 +79,7 @@ func TestRootErrorKVFormatter(t *testing.T) {
 		errors.KV("key1", "value1"),
 	)
 
-	expected := "root error {key1: value1}"
+	expected := "root error {key1=value1}"
 	if err.Error() != expected {
 		t.Errorf("expected '%s', got '%s'", expected, err.Error())
 	}

--- a/op.go
+++ b/op.go
@@ -1,13 +1,25 @@
 package errors
 
 import (
+	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 )
 
-// Op represents an operation in the error stack.
-type Op string
+var (
+	_ KeyValuer = Op("")
 
-var _ KeyValuer = Op("")
+	// VerboseOpOnAnonymousFunctions determines whether the Op should include file and line information
+	// for anonymous functions.
+	// If set to true, the Op will include the line number where the anonymous function was defined.
+	VerboseOpOnAnonymousFunctions = true
+)
+
+// Op represents an operation in the error stack. An Op is a string that describes an operation,
+// such as a function call or a method invocation, that is associated with an error.
+// It implements the KeyValuer interface, allowing it to be used as a key-value pair in errors.
+type Op string
 
 func (op Op) Key() any {
 	return opKey{}
@@ -43,4 +55,57 @@ func GetOpStack(err error) string {
 	}
 
 	return sb.String()
+}
+
+// opUnknownFunction is used when the function name cannot be determined.
+const opUnknownFunction Op = "<unknown function>"
+
+// getCallerOp retrieves the operation for the caller at the given program counter (pc).
+func getCallerOp(pc uintptr, alwaysIncludeLocation bool) Op {
+	funcForPc := runtime.FuncForPC(pc)
+	if funcForPc == nil {
+		return opUnknownFunction
+	}
+
+	funcName := funcForPc.Name()
+	funcName = discardPackagePath(funcName)
+
+	if alwaysIncludeLocation || (VerboseOpOnAnonymousFunctions && isAnonymousFunction(funcName)) {
+		file, line := funcForPc.FileLine(pc)
+		return Op(funcNameWithLocation(funcName, file, line))
+	}
+
+	return Op(funcName)
+}
+
+// isAnonymousFunction checks if the function name indicates an anonymous function.
+// It does this by checking if the function name contains a dot (.) and starts with "func" after the last dot.
+// If there isn't a dot in the function name, it checks if the function name starts with "func".
+func isAnonymousFunction(funcName string) bool {
+	idx := strings.LastIndex(funcName, ".")
+	if idx > 0 {
+		return strings.HasPrefix(funcName[idx+1:], "func")
+	}
+	return strings.HasPrefix(funcName, "func")
+}
+
+// funcNameWithLocation formats the function name with its file and line number.
+func funcNameWithLocation(funcName, file string, line int) string {
+	const lineNumberChars = 32 // " (<file>:<line>)"
+	var sb strings.Builder
+	sb.Grow(len(funcName) + lineNumberChars)
+	sb.WriteString(funcName)
+	sb.WriteString(" (")
+	sb.WriteString(filepath.Base(file))
+	sb.WriteString(":")
+	sb.WriteString(strconv.Itoa(line))
+	sb.WriteString(")")
+	return sb.String()
+}
+
+func discardPackagePath(s string) string {
+	if idx := strings.LastIndex(s, "/"); idx >= 0 {
+		return s[idx+1:]
+	}
+	return s
 }

--- a/with.go
+++ b/with.go
@@ -3,8 +3,6 @@ package errors
 import (
 	"reflect"
 	"runtime"
-	"strconv"
-	"strings"
 )
 
 var (
@@ -12,10 +10,6 @@ var (
 	// to errors when using the With function.
 	// If set to true, the Op will be automatically added to errors that do not already have an Op.
 	AutomaticallyAddOp = true
-	// VerboseOpOnAnonymousFunctions determines whether the Op should include file and line information
-	// for anonymous functions.
-	// If set to true, the Op will include the line number where the anonymous function was defined.
-	VerboseOpOnAnonymousFunctions = true
 
 	// ErrKeyNotComparable defines an error that is returned when a key in With is not comparable.
 	ErrKeyNotComparable = New("key is not comparable")
@@ -47,54 +41,10 @@ func With(err error, keyvalues ...KeyValuer) error {
 }
 
 func withAutomaticOp(err error) error {
-	op := Op(getWithCaller())
+	pc, _, _, _ := runtime.Caller(2)
+	op := getCallerOp(pc, false)
 	if ValueT[Op](err, opKey{}) == op {
 		return err // Op already exists, no need to add it again
 	}
-	return With(err, Op(getWithCaller()))
-}
-
-func getWithCaller() string {
-	pc, _, line, ok := runtime.Caller(3)
-	if !ok {
-		return "<unknown function>"
-	}
-
-	funcName := runtime.FuncForPC(pc).Name()
-	funcName = discardPackagePath(funcName)
-
-	if VerboseOpOnAnonymousFunctions && isAnonymousFunction(funcName) {
-		return funcNameWithLineNumber(funcName, line)
-	}
-
-	return funcName
-}
-
-// isAnonymousFunction checks if the function name indicates an anonymous function.
-// It does this by checking if the function name contains a dot (.) and starts with "func" after the last dot.
-// If there isn't a dot in the function name, it checks if the function name starts with "func".
-func isAnonymousFunction(funcName string) bool {
-	idx := strings.LastIndex(funcName, ".")
-	if idx > 0 {
-		return strings.HasPrefix(funcName[idx+1:], "func")
-	}
-	return strings.HasPrefix(funcName, "func")
-}
-
-func funcNameWithLineNumber(funcName string, line int) string {
-	const lineNumberChars = 12 // " (line XXXX)" has 12 characters
-	var sb strings.Builder
-	sb.Grow(len(funcName) + lineNumberChars)
-	sb.WriteString(funcName)
-	sb.WriteString(" (line ")
-	sb.WriteString(strconv.Itoa(line))
-	sb.WriteString(")")
-	return sb.String()
-}
-
-func discardPackagePath(s string) string {
-	if idx := strings.LastIndex(s, "/"); idx >= 0 {
-		return s[idx+1:]
-	}
-	return s
+	return With(err, op)
 }


### PR DESCRIPTION
Adds a helper function to recover from panics and automatically adds relevant key-values, like operation, code, severity and file where the panic occurred.

The `DontPanic` function will add and operation for the panicking function with file and line number.

The key-value format was change to `key=value` instead of `key: value` for better readability.